### PR TITLE
Use Path and PathBuf instead of strings where paths are handled

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,7 @@
 //! Manages configurations from commandline and settings file
 
+use std::path::PathBuf;
+
 use directories;
 use toml;
 use serde::Deserialize;
@@ -30,10 +32,10 @@ pub enum Mode {
 #[derive(Clone, Debug)]
 pub struct DecodeSettings {
     /// Input filename.
-    pub input_filename: String,
+    pub input_filename: PathBuf,
 
     /// Output filename.
-    pub output_filename: String,
+    pub output_filename: PathBuf,
 
     /// Whether to sync frames.
     pub sync: bool,
@@ -69,10 +71,10 @@ pub struct DecodeSettings {
 #[derive(Clone, Debug)]
 pub struct ResampleSettings {
     /// Input filename.
-    pub input_filename: String,
+    pub input_filename: PathBuf,
 
     /// Output filename.
-    pub output_filename: String,
+    pub output_filename: PathBuf,
 
     /// If we are exporting steps to WAV.
     pub export_wav: bool,
@@ -211,7 +213,7 @@ pub fn get_config() -> (bool, log::Level, Mode) {
 
     // Parse commandline
 
-    let mut input_filename: Option<String> = None;
+    let mut input_filename: Option<PathBuf> = None;
     let mut debug = false;
     let mut quiet = false;
     let mut wav_steps = false;
@@ -220,7 +222,7 @@ pub fn get_config() -> (bool, log::Level, Mode) {
     let mut contrast_adjustment: Option<String> = None;
     let mut profile: Option<String> = None;
     let mut print_version = false;
-    let mut output_filename: Option<String> = None;
+    let mut output_filename: Option<PathBuf> = None;
     let mut resample_output: Option<u32> = None;
     {
         let mut parser = argparse::ArgumentParser::new();
@@ -315,7 +317,7 @@ pub fn get_config() -> (bool, log::Level, Mode) {
 
             let settings = ResampleSettings {
                 input_filename,
-                output_filename: output_filename.unwrap_or("./output.png".to_string()),
+                output_filename: output_filename.unwrap_or_else(|| PathBuf::from("./output.png")),
                 export_wav: wav_steps,
                 export_resample_filtered,
                 output_rate: rate,
@@ -344,7 +346,7 @@ pub fn get_config() -> (bool, log::Level, Mode) {
 
             let settings = DecodeSettings {
                 input_filename,
-                output_filename: output_filename.unwrap_or("./output.png".to_string()),
+                output_filename: output_filename.unwrap_or_else(|| PathBuf::from("./output.png")),
                 export_wav: wav_steps,
                 export_resample_filtered,
                 sync,

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,10 +1,11 @@
 //! Contains the Context struct.
 
+use std::path::PathBuf;
+
 use dsp::{Signal, Rate};
 use noaa_apt::PX_PER_ROW;
 use err;
 use wav;
-
 
 /// Different kinds of steps available.
 #[derive(Debug, PartialEq)]
@@ -177,10 +178,8 @@ impl Context {
                         sample_format: hound::SampleFormat::Float,
                     };
 
-                    let mut filename = metadata.filename.to_string();
-                    filename.push_str(".wav");
-
-                    wav::write_wav(filename.as_str(), &step.signal, writer_spec)?;
+                    let filename = PathBuf::from(metadata.filename).with_extension("wav");
+                    wav::write_wav(&filename, &step.signal, writer_spec)?;
                 },
                 Variant::Signal => {
 
@@ -197,10 +196,8 @@ impl Context {
                         sample_format: hound::SampleFormat::Float,
                     };
 
-                    let mut filename = metadata.filename.to_string();
-                    filename.push_str(".wav");
-
-                    wav::write_wav(filename.as_str(), &step.signal, writer_spec)?;
+                    let filename = PathBuf::from(metadata.filename).with_extension("wav");
+                    wav::write_wav(&filename, &step.signal, writer_spec)?;
                 },
             };
         }

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -20,6 +20,7 @@
 //! back.
 
 use std::cell::RefCell;
+use std::path::PathBuf;
 
 use gtk;
 use gio;
@@ -574,31 +575,19 @@ fn run_noaa_apt(settings: config::GuiSettings, mode: Mode) -> err::Result<()> {
 
         widgets.start_button.set_sensitive(false);
 
-        // input_filename has to be a String instead of GString because I need it to
-        // implement Sync
-
-        let input_filename: String = widgets
+        let input_filename: PathBuf = widgets
             .input_file_chooser
             .get_filename() // Option<std::path::PathBuf>
-            .ok_or_else(|| err::Error::Internal("Select input file".to_string()))
-            .and_then(|path: std::path::PathBuf| {
-                 path.to_str()
-                     .ok_or_else(|| err::Error::Internal("Invalid character on input path".to_string()))
-                     .map(|s: &str| s.to_string())
-            })?;
+            .ok_or_else(|| err::Error::Internal("Select input file".to_string()))?;
 
-        // output_filename has to be a String instead of GString because I need it
-        // to implement Sync
-
-        let output_filename: String = widgets
+        let output_filename: PathBuf = widgets
             .output_entry
             .get_text()
-            .expect("Couldn't get decode_output_entry text")
-            .as_str()
-            .to_string();
+            .map(|text| PathBuf::from(text.as_str()))
+            .ok_or_else(|| err::Error::Internal("Select output file".to_string()))?;
 
-        if output_filename == "" {
-            return Err(err::Error::Internal("Select output filename".to_string()))
+        if output_filename.as_os_str().is_empty() {
+            return Err(err::Error::Internal("Select output filename".to_string()));
         }
 
         match mode {
@@ -641,7 +630,7 @@ fn run_noaa_apt(settings: config::GuiSettings, mode: Mode) -> err::Result<()> {
                     )),
                 }?;
 
-                debug!("Decode {} to {}", input_filename, output_filename);
+                debug!("Decode {} to {}", input_filename.display(), output_filename.display());
 
                 std::thread::spawn(move || {
                     let context = Context::decode(
@@ -693,7 +682,7 @@ fn run_noaa_apt(settings: config::GuiSettings, mode: Mode) -> err::Result<()> {
                     .expect("Couldn't get resample_step_check")
                     .get_active();
 
-                debug!("Resample {} as {} to {}", input_filename, rate, output_filename);
+                debug!("Resample {} as {} to {}", input_filename.display(), rate, output_filename.display());
 
                 widgets.start_button.set_sensitive(false);
                 std::thread::spawn(move || {
@@ -738,17 +727,12 @@ fn read_timestamp() -> err::Result<()> {
         let minute_spinner = widgets.minute_spinner.as_ref().expect("Couldn't get minute_spinner");
         let second_spinner = widgets.second_spinner.as_ref().expect("Couldn't get second_spinner");
 
-        let input_filename: String = widgets
+        let input_filename: PathBuf = widgets
             .input_file_chooser
             .get_filename() // Option<std::path::PathBuf>
-            .ok_or_else(|| err::Error::Internal("Select input file".to_string()))
-            .and_then(|path: std::path::PathBuf| {
-                 path.to_str()
-                     .ok_or_else(|| err::Error::Internal("Invalid character on input path".to_string()))
-                     .map(|s: &str| s.to_string())
-            })?;
+            .ok_or_else(|| err::Error::Internal("Select input file".to_string()))?;
 
-        let timestamp = misc::read_timestamp(input_filename.as_str())?;
+        let timestamp = misc::read_timestamp(&input_filename)?;
         let datetime = chrono::Local.timestamp(timestamp, 0);
 
         // GTK counts months from 0 to 11. Years and days are fine
@@ -770,12 +754,11 @@ fn write_timestamp() -> err::Result<()> {
         let minute_spinner = widgets.minute_spinner.as_ref().expect("Couldn't get minute_spinner");
         let second_spinner = widgets.second_spinner.as_ref().expect("Couldn't get second_spinner");
 
-        let output_filename: String = widgets
+        let output_filename: PathBuf = widgets
             .output_entry
             .get_text()
-            .expect("Couldn't get decode_output_entry text")
-            .as_str()
-            .to_string();
+            .map(|text| PathBuf::from(text.as_str()))
+            .ok_or_else(|| err::Error::Internal("Select output file".to_string()))?;
 
         let hour = hour_spinner.get_value_as_int();
         let minute = minute_spinner.get_value_as_int();
@@ -802,7 +785,7 @@ fn write_timestamp() -> err::Result<()> {
                 Err(err::Error::Internal("Ambiguous date or time".to_string())),
         }?;
 
-        misc::write_timestamp(datetime.timestamp(), output_filename.as_str())?;
+        misc::write_timestamp(datetime.timestamp(), &output_filename)?;
 
         Ok(())
     })

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -1,6 +1,7 @@
 //! Small things that don't fit anywhere else.
 
 use std::fs;
+use std::path::Path;
 
 use reqwest;
 use filetime;
@@ -189,7 +190,7 @@ pub fn percent(signal: &Signal, percent: f32) -> err::Result<(f32, f32)> {
 ///
 /// Returns the timestamp as the amount of seconds from the Unix epoch
 /// (Jan 1, 1970, 0:00:00hs UTC). I ignore the nanoseconds precision.
-pub fn read_timestamp(filename: &str) -> err::Result<i64> {
+pub fn read_timestamp(filename: &Path) -> err::Result<i64> {
     let metadata = fs::metadata(filename)
         .map_err(|_| err::Error::Internal(
             "Could not read metadata from input file".to_string()
@@ -209,7 +210,7 @@ pub fn read_timestamp(filename: &str) -> err::Result<i64> {
 ///
 /// The argument timestamp is the amount of seconds from the Unix epoch
 /// (Jan 1, 1970, 0:00:00hs UTC).
-pub fn write_timestamp(timestamp: i64, filename: &str) -> err::Result<()> {
+pub fn write_timestamp(timestamp: i64, filename: &Path) -> err::Result<()> {
     filetime::set_file_mtime(
         filename,
         filetime::FileTime::from_unix_time(timestamp, 0),

--- a/src/noaa_apt.rs
+++ b/src/noaa_apt.rs
@@ -67,8 +67,8 @@ pub fn resample_wav(
         sample_format: hound::SampleFormat::Int,
     };
 
-    info!("Writing WAV to '{}'", settings.output_filename);
-    context.status(0.8, format!("Writing WAV to '{}'", settings.output_filename));
+    info!("Writing WAV to '{}'", settings.output_filename.display());
+    context.status(0.8, format!("Writing WAV to '{}'", settings.output_filename.display()));
 
     wav::write_wav(&settings.output_filename, &resampled, writer_spec)?;
     misc::write_timestamp(timestamp, &settings.output_filename)?;
@@ -369,13 +369,13 @@ pub fn decode(
 
     // --------------------
 
-    context.status(0.95, format!("Writing PNG to '{}'", settings.output_filename));
+    context.status(0.95, format!("Writing PNG to '{}'", settings.output_filename.display()));
 
     // To use encoder.set()
     use png::HasParameters;
 
-    let path = std::path::Path::new(&settings.output_filename);
-    let file = std::fs::File::create(path)?;
+    let file = std::fs::File::create(&settings.output_filename)?;
+
     let buffer = &mut std::io::BufWriter::new(file);
 
     let height = signal.len() as u32 / PX_PER_ROW;

--- a/src/wav.rs
+++ b/src/wav.rs
@@ -1,5 +1,7 @@
 //! Functions for loading and saving WAV files.
 
+use std::path::Path;
+
 use hound;
 
 use dsp;
@@ -8,9 +10,8 @@ use err;
 
 
 /// Load wav file, return `Signal` and specs.
-pub fn load_wav(filename: &str) -> err::Result<(Signal, hound::WavSpec)> {
-
-    debug!("Loading WAV: {}", filename);
+pub fn load_wav(filename: &Path) -> err::Result<(Signal, hound::WavSpec)> {
+    debug!("Loading WAV: {}", filename.display());
 
     let mut reader = hound::WavReader::open(filename)?;
     let spec = reader.spec();
@@ -63,9 +64,8 @@ pub fn load_wav(filename: &str) -> err::Result<(Signal, hound::WavSpec)> {
 ///
 /// Only works for 32 bit float and 16 bit integer. As an input this function
 /// takes always a `Signal` but converts samples according to the WAV specs.
-pub fn write_wav(filename: &str, signal: &Signal, spec: hound::WavSpec) -> err::Result<()> {
-
-    debug!("Normalizing samples and writing WAV to '{}'", filename);
+pub fn write_wav(filename: &Path, signal: &Signal, spec: hound::WavSpec) -> err::Result<()> {
+    debug!("Normalizing samples and writing WAV to '{}'", filename.display());
 
     let max = dsp::get_max(&signal)?;
     debug!("Max: {}", max);


### PR DESCRIPTION
Use Rust's `Path` and `PathBuf` for handling paths. Rust's paths are constructed using operating system's strings instead of UTF-8 strings (not all UTF-8 strings are valid paths in different systems).