### PR TITLE
Fix missing output_tips for Resample and Timestamp modes

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -196,6 +196,7 @@ fn build_ui(
     let second_spinner;
     let timezone_label;
     let calendar;
+    let output_filename_extension;
     match mode {
         Mode::Decode => {
             rate_spinner = None;
@@ -217,6 +218,7 @@ fn build_ui(
             second_spinner = None;
             timezone_label = None;
             calendar = None;
+            output_filename_extension = ".png";
         },
         Mode::Resample => {
             rate_spinner = Some(builder.get_object("rate_spinner")
@@ -236,6 +238,7 @@ fn build_ui(
             second_spinner = None;
             timezone_label = None;
             calendar = None;
+            output_filename_extension = ".wav";
         },
         Mode::Timestamp => {
             rate_spinner = None;
@@ -257,6 +260,7 @@ fn build_ui(
                 .expect("Couldn't get timezone_label"));
             calendar = Some(builder.get_object("calendar")
                 .expect("Couldn't get calendar"));
+            output_filename_extension = ".wav";
         }
     };
 
@@ -379,7 +383,7 @@ fn build_ui(
 
     // Configure output_tips to update when output_entry changes
 
-    widgets.output_entry.connect_changed(|_| {
+    widgets.output_entry.connect_changed(move |_| {
         borrow_widgets(|widgets| {
 
             // get output_filename. Early abort if error or empty.
@@ -409,11 +413,11 @@ fn build_ui(
                 };
             }
 
-            // filename extension (png expected)
-            if output_filename.ends_with(".png") == false {
-                tips.push_str("Warning: you are advised to use a .png file extension.\n");
+            // filename extension (png or wav expected, depends on mode)
+            if output_filename.ends_with(output_filename_extension) == false {
+                tips.push_str(&format!("Warning: you are advised to use a \"{}\" file extension.\n", output_filename_extension));
             }
-
+        
             // file exists?
             if Path::new(&output_filename).exists() {
                 tips.push_str("Warning: the file already exists, it will be overwritten.");

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -417,7 +417,7 @@ fn build_ui(
             if output_filename.ends_with(output_filename_extension) == false {
                 tips.push_str(&format!("Warning: you are advised to use a \"{}\" file extension.\n", output_filename_extension));
             }
-        
+
             // file exists?
             if Path::new(&output_filename).exists() {
                 tips.push_str("Warning: the file already exists, it will be overwritten.");

--- a/src/resample.glade
+++ b/src/resample.glade
@@ -77,6 +77,24 @@
           </packing>
         </child>
         <child>
+          <object class="GtkLabel" id="output_tips">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">start</property>
+            <property name="wrap">True</property>
+            <property name="wrap_mode">char</property>
+            <property name="selectable">True</property>
+            <property name="max_width_chars">50</property>
+            <attributes>
+              <attribute name="style" value="italic"/>
+            </attributes>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">2</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkLabel">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
@@ -85,7 +103,7 @@
           </object>
           <packing>
             <property name="left_attach">0</property>
-            <property name="top_attach">2</property>
+            <property name="top_attach">3</property>
           </packing>
         </child>
         <child>
@@ -101,7 +119,7 @@
           </object>
           <packing>
             <property name="left_attach">1</property>
-            <property name="top_attach">2</property>
+            <property name="top_attach">3</property>
           </packing>
         </child>
       </object>

--- a/src/timestamp.glade
+++ b/src/timestamp.glade
@@ -104,6 +104,24 @@
             <property name="top_attach">1</property>
           </packing>
         </child>
+        <child>
+          <object class="GtkLabel" id="output_tips">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">start</property>
+            <property name="wrap">True</property>
+            <property name="wrap_mode">char</property>
+            <property name="selectable">True</property>
+            <property name="max_width_chars">50</property>
+            <attributes>
+              <attribute name="style" value="italic"/>
+            </attributes>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">2</property>
+          </packing>
+        </child>
       </object>
       <packing>
         <property name="expand">False</property>


### PR DESCRIPTION
Also, set expected filename extension to .png or .wav accordingly.

Not sure if using `output_filename_extension` for each mode is better than matching again on `mode` inside the closure (line 436), but I had to use the `move` keyword to take ownership of the environment, since neither of those values are available inside the closure.

Please let me know if there is a better way to set the recommended file extension.
