### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -546,6 +546,17 @@ pub fn get_config() -> (bool, log::Level, Mode) {
             };
 
             let mut orbit_settings = None;
+            if let Some(s_name) = &sat_name {
+                if let Some(r_time) = &ref_time {
+                    orbit_settings = Some(OrbitSettings {
+                        sat_name: s_name.to_owned(),
+                        custom_tle,
+                        ref_time: r_time.to_owned(),
+                        draw_map: draw_map.to_owned(),
+                    });
+                };
+            };
+
             if sat_name.is_none() || ref_time.is_none() {
                 if let Rotate::Orbit = rotate {
                     println!("Can't rotate automatically if no satellite and \
@@ -556,13 +567,6 @@ pub fn get_config() -> (bool, log::Level, Mode) {
                     println!("Can't draw map if no satellite and time is provided");
                     std::process::exit(0);
                 }
-            } else {
-                orbit_settings = Some(OrbitSettings {
-                    sat_name: sat_name.unwrap(),
-                    custom_tle,
-                    ref_time: ref_time.unwrap(),
-                    draw_map,
-                });
             }
 
             return (check_updates, verbosity, Mode::Decode {
@@ -573,7 +577,7 @@ pub fn get_config() -> (bool, log::Level, Mode) {
                 sync: arg_sync,
                 contrast_adjustment,
                 rotate,
-                orbit_settings: orbit_settings,
+                orbit_settings,
             });
         }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -132,7 +132,7 @@ impl Context {
     }
 
     /// Export step.
-    pub fn step(&mut self, step: Step<'_>) -> err::Result<()> {
+    pub fn step(&mut self, step: &Step<'_>) -> err::Result<()> {
         if self.export_wav {
 
             debug!("Got step: {}", step.id);

--- a/src/context.rs
+++ b/src/context.rs
@@ -132,7 +132,7 @@ impl Context {
     }
 
     /// Export step.
-    pub fn step(&mut self, step: &Step<'_>) -> err::Result<()> {
+    pub fn step(&mut self, step: Step<'_>) -> err::Result<()> {
         if self.export_wav {
 
             debug!("Got step: {}", step.id);

--- a/src/gui/gui.rs
+++ b/src/gui/gui.rs
@@ -276,7 +276,7 @@ fn init_widgets(widgets: &Widgets) {
 
             // If saving in CWD
 
-            if !output_filename.starts_with("/") {
+            if !output_filename.starts_with('/') {
                 match env::current_dir() {
                     Ok(cwd) => {
                         folder_tip_label.set_text(&format!("{}", cwd.display()));

--- a/src/gui/misc.rs
+++ b/src/gui/misc.rs
@@ -113,7 +113,7 @@ where W: glib::object::IsA<gtk::Window>
             window.clone().upcast::<gtk::Window>().get_screen().as_ref(),
             url,
             gtk::get_current_event_time(),
-        ).or_else(|_| Err(err::Error::Internal("Could not open browser".to_string())))
+        ).map_err(|_| err::Error::Internal("Could not open browser".to_string()))
     }
 }
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -36,7 +36,7 @@ pub fn draw_map(
         SatName::Noaa19 => "NOAA 19",
     }.to_string();
 
-    let mut sat = sats.iter()
+    let sat = sats.iter()
         .find(|&sat| sat.name.as_ref() == Some(&sat_string))
         .ok_or_else(||
             err::Error::Internal(format!("Satellite \"{}\" not found in TLE", sat_string))
@@ -55,7 +55,7 @@ pub fn draw_map(
     for i in 0..height {
         let t = start_time + line_duration * i as i32;
         // TODO: Remove unwrap()
-        let result = satellite::propogation::propogate_datetime(&mut sat, t).unwrap();
+        let result = satellite::propogation::propogate_datetime(&sat, t).unwrap();
         let gmst = satellite::propogation::gstime::gstime_datetime(t);
         let sat_pos = satellite::transforms::eci_to_geodedic(&result.position, gmst);
         sat_positions.push((sat_pos.latitude, sat_pos.longitude));

--- a/src/map.rs
+++ b/src/map.rs
@@ -30,11 +30,7 @@ pub fn draw_map(
     // Load satellite from TLE
 
     let (sats, _errors) = satellite::io::parse_multiple(&tle);
-    let sat_string = match sat_name {
-        SatName::Noaa15 => "NOAA 15",
-        SatName::Noaa18 => "NOAA 18",
-        SatName::Noaa19 => "NOAA 19",
-    }.to_string();
+    let sat_string = sat_name.to_string();
 
     let sat = sats.iter()
         .find(|&sat| sat.name.as_ref() == Some(&sat_string))

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -403,7 +403,7 @@ pub fn infer_time_sat(settings: &Settings, path: &Path) ->
 
 /// Try downloading TLE from URL.
 fn download_tle(addr: &str) -> err::Result<String> {
-    Ok(reqwest::blocking::get(addr)?.text()?.to_string())
+    Ok(reqwest::blocking::get(addr)?.text()?)
 }
 
 /// Try reading TLE from file.

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -330,9 +330,9 @@ fn parse_filename(filename: &str,
                         sat = match fname_chars.as_str()[0..9].parse::<u32>() {
                             Ok(freq) => closest_freq(
                                 &[
-                                    (137620000, SatName::Noaa15),
-                                    (137912500, SatName::Noaa18),
-                                    (137100000, SatName::Noaa19),
+                                    (137_620_000, SatName::Noaa15),
+                                    (137_912_500, SatName::Noaa18),
+                                    (137_100_000, SatName::Noaa19),
                                 ], freq
                             ),
                             Err(_) => return None, // Exit entire function

--- a/src/noaa_apt.rs
+++ b/src/noaa_apt.rs
@@ -88,6 +88,16 @@ pub enum SatName {
     Noaa19,
 }
 
+impl ToString for SatName {
+    fn to_string(&self) -> String {
+        match self {
+            SatName::Noaa15 => "NOAA 15".to_owned(),
+            SatName::Noaa18 => "NOAA 18".to_owned(),
+            SatName::Noaa19 => "NOAA 19".to_owned(),
+        }
+    }
+}
+
 /// Load WAV from file.
 ///
 /// Returns the Signal and its sample rate.

--- a/src/noaa_apt.rs
+++ b/src/noaa_apt.rs
@@ -142,7 +142,7 @@ pub fn process(
 
     let mut img: GrayImage = GrayImage::from_vec(
             PX_PER_ROW, height, map(&signal, low, high))
-        .ok_or(err::Error::Internal(
+        .ok_or_else(|| err::Error::Internal(
             "Could not create image, wrong buffer length".to_string()))?;
     
     if let Contrast::Histogram = contrast_adjustment {
@@ -181,7 +181,7 @@ pub fn process(
             img = processing::rotate(&img)?;
         },
         Rotate::Orbit => {
-            if let Some(orbit_settings) = orbit.clone() {
+            if let Some(orbit_settings) = orbit {
                 if processing::south_to_north_pass(&orbit_settings)? {
                     context.status(0.90, "Rotating output image".to_string());
                     img = processing::rotate(&img)?;

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -43,11 +43,7 @@ pub fn south_to_north_pass(orbit_settings: &OrbitSettings) -> err::Result<bool> 
     };
 
     let (sats, _errors) = satellite::io::parse_multiple(&tle);
-    let sat_string = match orbit_settings.sat_name {
-        SatName::Noaa15 => "NOAA 15",
-        SatName::Noaa18 => "NOAA 18",
-        SatName::Noaa19 => "NOAA 19",
-    }.to_string();
+    let sat_string = orbit_settings.sat_name.to_string();
 
     let sat = sats.iter()
         .find(|&sat| sat.name.as_ref() == Some(&sat_string))

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -7,7 +7,7 @@ use crate::decode::PX_PER_CHANNEL;
 use crate::err;
 use crate::geo;
 use crate::misc;
-use crate::noaa_apt::{Image, OrbitSettings, RefTime, SatName};
+use crate::noaa_apt::{Image, OrbitSettings, RefTime};
 
 
 /// Rotate image without changing the location of the channels.

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -49,7 +49,7 @@ pub fn south_to_north_pass(orbit_settings: &OrbitSettings) -> err::Result<bool> 
         SatName::Noaa19 => "NOAA 19",
     }.to_string();
 
-    let mut sat = sats.iter()
+    let sat = sats.iter()
         .find(|&sat| sat.name.as_ref() == Some(&sat_string))
         .ok_or_else(||
             err::Error::Internal(format!("Satellite \"{}\" not found in TLE", sat_string))
@@ -61,14 +61,14 @@ pub fn south_to_north_pass(orbit_settings: &OrbitSettings) -> err::Result<bool> 
     };
 
     // TODO: Remove unwrap()
-    let result = satellite::propogation::propogate_datetime(&mut sat, start_time).unwrap();
+    let result = satellite::propogation::propogate_datetime(&sat, start_time).unwrap();
     let gmst = satellite::propogation::gstime::gstime_datetime(start_time);
     let sat_start_pos = satellite::transforms::eci_to_geodedic(&result.position, gmst);
 
     let end_time = start_time + chrono::Duration::seconds(2);
 
     // TODO: Remove unwrap()
-    let result = satellite::propogation::propogate_datetime(&mut sat, end_time).unwrap();
+    let result = satellite::propogation::propogate_datetime(&sat, end_time).unwrap();
     let gmst = satellite::propogation::gstime::gstime_datetime(end_time);
     let sat_end_pos = satellite::transforms::eci_to_geodedic(&result.position, gmst);
 


### PR DESCRIPTION
This fixes all but one clippy warnings: 

```
warning: module has the same name as its containing module
 --> src/gui/mod.rs:1:1
  |
1 | mod gui;
  | ^^^^^^^^
  |
  = note: `#[warn(clippy::module_inception)]` on by default
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#module_inception
```

Not sure if you want to do something about this one. We could rename `src/gui/gui.rs` to `src/gui/ui.rs` and use `mod ui` instead.

Also, `impl ToString for SatName`, so we don't have to match on SatName each time we need the string representation.