### PR TITLE
Add false color and rotate channels in place

### DIFF
--- a/docs/default_settings.toml
+++ b/docs/default_settings.toml
@@ -69,6 +69,14 @@ default_countries_color = [255, 255, 0, 255]
 default_states_color = [255, 255, 0, 150]
 default_lakes_color = [50, 200, 200, 255]
 
+[false_color]
+
+# Values used as thresholds for false color algorithm:
+# [water, vegetation, clouds]
+# Valid values: 0..255 with water < vegetation < clouds
+default_false_color_values = [50, 105, 137]
+
+
 [profiles]
 
 default_profile = "standard"
@@ -118,7 +126,7 @@ default_profile = "standard"
     wav_resample_atten = 30
     wav_resample_delta_freq = 0.2
 
-    # Should be used temporairly if there is a problem with the "standard"
+    # Should be used temporarily if there is a problem with the "standard"
     # profile in some images. But leave a bug report in that case.
     [profiles.slow]
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -279,9 +279,11 @@ slant. See also [Troubleshooting](./usage.html#troubleshooting).
 ### Configuration file
 
 The first time you open noaa-apt, a default configuration file will be created
-on `~/.config/noaa-apt/settings.toml` or
-`C:\Users\[USER]\AppData\Roaming\noaa-apt\settings.toml` depending on your
-operating system.
+depending on your operating system:
+
+- Linux: `~/.config/noaa-apt/settings.toml`
+- Windows: `C:\Users\[USER]\AppData\Roaming\noaa-apt\settings.toml`
+- MacOS: `~/Library/Preferences/ar.com.mbernardi.noaa-apt/settings.toml`
 
 There you can change some advanced settings, be sure to check it if you plan to
 use noaa-apt for automatic image reception. [Here you can see the default

--- a/src/config.rs
+++ b/src/config.rs
@@ -348,7 +348,7 @@ pub fn get_config() -> (bool, log::Level, Mode) {
             to North.")
             .metavar("METHOD");
         parser.refer(&mut arg_false_color)
-            .add_option(&["-F", "--false-color"], argparse::StoreFalse,
+            .add_option(&["-F", "--false-color"], argparse::StoreTrue,
             "Attempt to produce a colored image, from the grayscale channel \
             and IR values. Experimental. Works best with \"--contrast telemetry\".");
         parser.refer(&mut arg_start_time)

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,6 +58,7 @@ pub enum Mode {
         contrast_adjustment: Contrast,
         rotate: Rotate,
         orbit_settings: Option<OrbitSettings>,
+        false_color: bool,
     },
 
     /// Resample image from commandline.
@@ -280,6 +281,7 @@ pub fn get_config() -> (bool, log::Level, Mode) {
     let mut arg_vscale: Option<f64> = None;
     let mut arg_rotate: Option<String> = None;
     let mut arg_rotate_deprecated = false;
+    let mut arg_false_color = false;
     {
         let mut parser = argparse::ArgumentParser::new();
         parser.set_description("Decode NOAA APT images from WAV files. Run \
@@ -345,6 +347,10 @@ pub fn get_config() -> (bool, log::Level, Mode) {
             calculations and reception time to determine if the pass was South \
             to North.")
             .metavar("METHOD");
+        parser.refer(&mut arg_false_color)
+            .add_option(&["-F", "--false-color"], argparse::StoreFalse,
+            "Attempt to produce a colored image, from the grayscale channel \
+            and IR values. Experimental. Works best with \"--contrast telemetry\".");
         parser.refer(&mut arg_start_time)
             .add_option(&["-t", "--start-time"], argparse::StoreOption,
             "Provide recording start time, used for orbit calculations. Use \
@@ -577,6 +583,7 @@ pub fn get_config() -> (bool, log::Level, Mode) {
                 sync: arg_sync,
                 contrast_adjustment,
                 rotate,
+                false_color: arg_false_color,
                 orbit_settings,
             });
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -124,6 +124,9 @@ pub struct Settings {
 
     /// Default lakes color as RGBA.
     pub default_lakes_color: (u8, u8, u8, u8),
+
+    /// Default thresholds for false color (water, vegetation, clouds)
+    pub default_false_color_values: (u8, u8, u8),
 }
 
 /// Holds the deserialized raw parsed settings file.
@@ -134,6 +137,7 @@ struct DeSettings {
     timestamps: DeTimestamps,
     profiles: DeProfiles,
     map_overlay: DeMapOverlay,
+    false_color: DeFalseColor,
 }
 
 /// Holds the deserialized raw parsed timestamps table
@@ -150,6 +154,12 @@ struct DeMapOverlay {
     default_countries_color: (u8, u8, u8, u8),
     default_states_color: (u8, u8, u8, u8),
     default_lakes_color: (u8, u8, u8, u8),
+}
+
+/// Holds the deserialized raw parsed false color thresholds
+#[derive(Deserialize)]
+struct DeFalseColor {
+    default_false_color_values: (u8, u8, u8),
 }
 
 /// Holds the deserialized raw parsed profiles table
@@ -435,6 +445,7 @@ pub fn get_config() -> (bool, log::Level, Mode) {
         default_countries_color: de_settings.map_overlay.default_countries_color,
         default_states_color: de_settings.map_overlay.default_states_color,
         default_lakes_color: de_settings.map_overlay.default_lakes_color,
+        default_false_color_values: de_settings.false_color.default_false_color_values,
     };
 
     // If set, then the program will be used as a command-line one, otherwise we

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -24,17 +24,15 @@ pub const PX_SPACE_DATA: u32 = 47;
 pub const PX_CHANNEL_IMAGE_DATA: u32 = 909;
 
 /// Telemetry data.
+#[allow(dead_code)]
 pub const PX_TELEMETRY_DATA: u32 = 45;
 
 // Source: https://www.sigidwiki.com/wiki/Automatic_Picture_Transmission_(APT)#Structure
-/// Pixels per channel.
-pub const PX_PER_CHANNEL: u32 = 
-    PX_SYNC_FRAME + 
-    PX_SPACE_DATA + 
-    PX_CHANNEL_IMAGE_DATA +
-    PX_TELEMETRY_DATA;
+/// Pixels per channel. A channel contains:
+/// PX_SYNC_FRAME | PX_SPACE_DATA | PX_CHANNEL_IMAGE_DATA | PX_TELEMETRY_DATA
+pub const PX_PER_CHANNEL: u32 = 1040;
 
-/// Pixels per image row, 1040 * 2 = 2080.
+/// Pixels per image row. A row contains 2 channels.
 pub const PX_PER_ROW: u32 = PX_PER_CHANNEL * 2;
 
 /// AM carrier frequency in Hz.

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -14,11 +14,28 @@ use crate::filters;
 /// This signal has one sample per pixel.
 pub const FINAL_RATE: u32 = 4160;
 
-/// Pixels per image row.
-pub const PX_PER_ROW: u32 = 2080;
+/// Channel sync frame.
+pub const PX_PER_SYNC: u32 = 39;
 
+/// Deep space data and minute markers.
+pub const PX_PER_SPACE_DATA: u32 = 47;
+
+/// Channel image data.
+pub const PX_PER_CHANNEL_IMAGE_DATA: u32 = 909;
+
+/// Telemetry data.
+pub const PX_PER_TELEMETRY_DATA: u32 = 45;
+
+// Source: https://www.sigidwiki.com/wiki/Automatic_Picture_Transmission_(APT)#Structure
 /// Pixels per channel.
-pub const PX_PER_CHANNEL: u32 = PX_PER_ROW / 2;
+pub const PX_PER_CHANNEL: u32 = 
+    PX_PER_SYNC + 
+    PX_PER_SPACE_DATA + 
+    PX_PER_CHANNEL_IMAGE_DATA +
+    PX_PER_TELEMETRY_DATA;
+
+/// Pixels per image row, 1040 * 2 = 2080.
+pub const PX_PER_ROW: u32 = PX_PER_CHANNEL * 2;
 
 /// AM carrier frequency in Hz.
 pub const CARRIER_FREQ: u32 = 2400;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -14,25 +14,25 @@ use crate::filters;
 /// This signal has one sample per pixel.
 pub const FINAL_RATE: u32 = 4160;
 
-/// Channel sync frame.
-pub const PX_PER_SYNC: u32 = 39;
+/// Channel sync frame, in pixels.
+pub const PX_SYNC_FRAME: u32 = 39;
 
 /// Deep space data and minute markers.
-pub const PX_PER_SPACE_DATA: u32 = 47;
+pub const PX_SPACE_DATA: u32 = 47;
 
 /// Channel image data.
-pub const PX_PER_CHANNEL_IMAGE_DATA: u32 = 909;
+pub const PX_CHANNEL_IMAGE_DATA: u32 = 909;
 
 /// Telemetry data.
-pub const PX_PER_TELEMETRY_DATA: u32 = 45;
+pub const PX_TELEMETRY_DATA: u32 = 45;
 
 // Source: https://www.sigidwiki.com/wiki/Automatic_Picture_Transmission_(APT)#Structure
 /// Pixels per channel.
 pub const PX_PER_CHANNEL: u32 = 
-    PX_PER_SYNC + 
-    PX_PER_SPACE_DATA + 
-    PX_PER_CHANNEL_IMAGE_DATA +
-    PX_PER_TELEMETRY_DATA;
+    PX_SYNC_FRAME + 
+    PX_SPACE_DATA + 
+    PX_CHANNEL_IMAGE_DATA +
+    PX_TELEMETRY_DATA;
 
 /// Pixels per image row, 1040 * 2 = 2080.
 pub const PX_PER_ROW: u32 = PX_PER_CHANNEL * 2;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -33,7 +33,7 @@ pub const PX_TELEMETRY_DATA: u32 = 45;
 pub const PX_PER_CHANNEL: u32 = 1040;
 
 /// Pixels per image row. A row contains 2 channels.
-pub const PX_PER_ROW: u32 = PX_PER_CHANNEL * 2;
+pub const PX_PER_ROW: u32 = 2080;
 
 /// AM carrier frequency in Hz.
 pub const CARRIER_FREQ: u32 = 2400;

--- a/src/default_settings.toml
+++ b/src/default_settings.toml
@@ -69,6 +69,14 @@ default_countries_color = [255, 255, 0, 255]
 default_states_color = [255, 255, 0, 150]
 default_lakes_color = [50, 200, 200, 255]
 
+[false_color]
+
+# Values used as thresholds for false color algorithm:
+# [water, vegetation, clouds]
+# Valid values: 0..255 with water < vegetation < clouds
+default_false_color_values = [50, 105, 137]
+
+
 [profiles]
 
 default_profile = "standard"
@@ -118,7 +126,7 @@ default_profile = "standard"
     wav_resample_atten = 30
     wav_resample_delta_freq = 0.2
 
-    # Should be used temporairly if there is a problem with the "standard"
+    # Should be used temporarily if there is a problem with the "standard"
     # profile in some images. But leave a bug report in that case.
     [profiles.slow]
 

--- a/src/gui/main.glade
+++ b/src/gui/main.glade
@@ -414,7 +414,7 @@
                                               <packing>
                                                 <property name="expand">False</property>
                                                 <property name="fill">True</property>
-                                                <property name="position">0</property>
+                                                <property name="position">2</property>
                                               </packing>
                                             </child>
                                           </object>

--- a/src/gui/main.glade
+++ b/src/gui/main.glade
@@ -402,6 +402,21 @@
                                                 <property name="position">1</property>
                                               </packing>
                                             </child>
+                                            <child>
+                                              <object class="GtkCheckButton" id="p_false_color_check">
+                                                <property name="label" translatable="yes">False color (experimental)</property>
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="receives_default">False</property>
+                                                <property name="tooltip_text" translatable="yes">Attempt to produce a color image from grayscale data. Experimental. Works best with telemetry based contrast adjustment.</property>
+                                                <property name="draw_indicator">True</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
                                           </object>
                                         </child>
                                         <child type="label_item">

--- a/src/gui/state.rs
+++ b/src/gui/state.rs
@@ -249,7 +249,7 @@ impl Widgets {
             dec_decode_button:       builder.get_object("dec_decode_button"      ).expect("Couldn't get dec_decode_button"      ),
 
             p_contrast_combo:        builder.get_object("p_contrast_combo"       ).expect("Couldn't get p_contrast_combo"       ),
-            p_false_color_check:     builder.get_object("p_false_color_check"     ).expect("Couldn't get p_false_color_check"   ),
+            p_false_color_check:     builder.get_object("p_false_color_check"    ).expect("Couldn't get p_false_color_check"    ),
             p_rotate_combo:          builder.get_object("p_rotate_combo"         ).expect("Couldn't get p_rotate_combo"         ),
             p_satellite_combo:       builder.get_object("p_satellite_combo"      ).expect("Couldn't get p_satellite_combo"      ),
             p_custom_tle_check:      builder.get_object("p_custom_tle_check"     ).expect("Couldn't get p_custom_tle_check"     ),

--- a/src/gui/state.rs
+++ b/src/gui/state.rs
@@ -159,6 +159,7 @@ pub struct Widgets {
 
     pub p_contrast_combo:          gtk::ComboBoxText,
     pub p_rotate_combo:            gtk::ComboBoxText,
+    pub p_false_color_check:       gtk::CheckButton,
     pub p_satellite_combo:         gtk::ComboBoxText,
     pub p_custom_tle_check:        gtk::CheckButton,
     pub p_custom_tle_chooser:      gtk::FileChooserButton,
@@ -248,6 +249,7 @@ impl Widgets {
             dec_decode_button:       builder.get_object("dec_decode_button"      ).expect("Couldn't get dec_decode_button"      ),
 
             p_contrast_combo:        builder.get_object("p_contrast_combo"       ).expect("Couldn't get p_contrast_combo"       ),
+            p_false_color_check:     builder.get_object("p_false_color_check"     ).expect("Couldn't get p_false_color_check"   ),
             p_rotate_combo:          builder.get_object("p_rotate_combo"         ).expect("Couldn't get p_rotate_combo"         ),
             p_satellite_combo:       builder.get_object("p_satellite_combo"      ).expect("Couldn't get p_satellite_combo"      ),
             p_custom_tle_check:      builder.get_object("p_custom_tle_check"     ).expect("Couldn't get p_custom_tle_check"     ),

--- a/src/gui/work.rs
+++ b/src/gui/work.rs
@@ -242,6 +242,8 @@ pub fn process() {
 
         let resample_step = widgets.dec_resample_step_check.get_active();
 
+        let false_color = widgets.p_false_color_check.get_active();
+
         let contrast_adjustment: Contrast = match widgets.p_contrast_combo
             .get_active_id()
             .as_ref()
@@ -449,6 +451,7 @@ pub fn process() {
                 &signal,
                 contrast_adjustment,
                 rotate,
+                false_color,
                 Some(orbit),
             ));
         });

--- a/src/gui/work.rs
+++ b/src/gui/work.rs
@@ -448,6 +448,7 @@ pub fn process() {
             );
             callback(noaa_apt::process(
                 &mut context,
+                &settings,
                 &signal,
                 contrast_adjustment,
                 rotate,

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,6 +114,7 @@ fn inner_main() -> err::Result<()> {
 
             let img = noaa_apt::process(
                 &mut context,
+                &settings,
                 &raw_data,
                 contrast_adjustment,
                 rotate,

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,7 @@ fn inner_main() -> err::Result<()> {
             sync,
             contrast_adjustment,
             rotate,
+            false_color,
             orbit_settings,
         } => {
 
@@ -116,6 +117,7 @@ fn inner_main() -> err::Result<()> {
                 &raw_data,
                 contrast_adjustment,
                 rotate,
+                false_color,
                 orbit_settings,
             )?;
 

--- a/src/noaa_apt.rs
+++ b/src/noaa_apt.rs
@@ -201,7 +201,7 @@ pub fn process(
                 warn!("Can't rotate automatically if no orbit information is provided");
             }
         },
-        Rotate::No => {}
+        Rotate::No => {},
     }
 
     Ok(img)
@@ -236,7 +236,7 @@ mod tests {
             -10., -5., -1., 0., 1., 2.4, 50., 120., 199.6, 255., 256., 300.];
 
         // Shift values somewhere
-        let shifted_values: Signal = 
+        let shifted_values: Signal =
             test_values.iter().map(|x| x * 123.123 - 234.234).collect();
 
         // See where 0 and 255 end up after that

--- a/src/noaa_apt.rs
+++ b/src/noaa_apt.rs
@@ -189,13 +189,13 @@ pub fn process(
     match rotate {
         Rotate::Yes => {
             context.status(0.90, "Rotating output image".to_string());
-            img = processing::rotate(&img)?;
+            processing::rotate(&mut img);
         },
         Rotate::Orbit => {
             if let Some(orbit_settings) = orbit {
                 if processing::south_to_north_pass(&orbit_settings)? {
                     context.status(0.90, "Rotating output image".to_string());
-                    img = processing::rotate(&img)?;
+                    processing::rotate(&mut img);
                 }
             } else {
                 warn!("Can't rotate automatically if no orbit information is provided");

--- a/src/noaa_apt.rs
+++ b/src/noaa_apt.rs
@@ -17,7 +17,7 @@ use crate::map;
 use crate::misc;
 use crate::processing;
 use crate::telemetry;
-use crate::wav;
+use crate::{config, wav};
 
 pub type Image = image::RgbaImage;
 
@@ -108,6 +108,7 @@ pub fn load(input_filename: &Path) -> err::Result<(Signal, Rate)> {
 
 pub fn process(
     context: &mut Context,
+    settings: &config::Settings,
     signal: &Signal,
     contrast_adjustment: Contrast,
     rotate: Rotate,
@@ -161,7 +162,7 @@ pub fn process(
     let mut img: Image = image::DynamicImage::ImageLuma8(img).into_rgba(); // convert to RGBA
 
     if false_color {
-        processing::false_color(&mut img);
+        processing::false_color(&mut img, settings.default_false_color_values);
     }
     // --------------------
 

--- a/src/noaa_apt.rs
+++ b/src/noaa_apt.rs
@@ -124,14 +124,14 @@ pub fn process(
             let high = telemetry.get_wedge_value(8, None);
 
             (low, high)
-        }
+        },
         Contrast::Percent(p) => {
             context.status(
                 0.1,
                 format!("Adjusting contrast using {} percent", p * 100.),
             );
             misc::percent(&signal, p)?
-        }
+        },
         Contrast::MinMax | Contrast::Histogram => {
             context.status(0.1, "Mapping values".to_string());
             let low: f32 = *dsp::get_min(&signal)?;
@@ -179,7 +179,7 @@ pub fn process(
                 orbit_settings.ref_time,
                 map_settings,
                 orbit_settings.sat_name,
-                tle,
+                tle
             )?;
         }
     }
@@ -190,7 +190,7 @@ pub fn process(
         Rotate::Yes => {
             context.status(0.90, "Rotating output image".to_string());
             img = processing::rotate(&img)?;
-        }
+        },
         Rotate::Orbit => {
             if let Some(orbit_settings) = orbit {
                 if processing::south_to_north_pass(&orbit_settings)? {
@@ -200,7 +200,7 @@ pub fn process(
             } else {
                 warn!("Can't rotate automatically if no orbit information is provided");
             }
-        }
+        },
         Rotate::No => {}
     }
 
@@ -230,13 +230,14 @@ mod tests {
 
     #[test]
     fn test_map() {
-        let expected: Vec<u8> = vec![0, 0, 0, 0, 1, 2, 50, 120, 200, 255, 255, 255];
+        let expected: Vec<u8> = vec![
+            0, 0, 0, 0, 1, 2, 50, 120, 200, 255, 255, 255];
         let test_values: Signal = vec![
-            -10., -5., -1., 0., 1., 2.4, 50., 120., 199.6, 255., 256., 300.,
-        ];
+            -10., -5., -1., 0., 1., 2.4, 50., 120., 199.6, 255., 256., 300.];
 
         // Shift values somewhere
-        let shifted_values: Signal = test_values.iter().map(|x| x * 123.123 - 234.234).collect();
+        let shifted_values: Signal = 
+            test_values.iter().map(|x| x * 123.123 - 234.234).collect();
 
         // See where 0 and 255 end up after that
         let low = 0. * 123.123 - 234.234;

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -22,11 +22,16 @@ pub fn rotate(img: &mut Image) {
     info!("Rotating image");
 
     // where the actual image data starts, past the sync frames and deep space band
-    let x_offset = PX_SYNC_FRAME + PX_SPACE_DATA - 1;
+    let x_offset = PX_SYNC_FRAME + PX_SPACE_DATA - 1; // !
 
-    // Note: not sure why the (-1) offsets were needed (lines marked with // !), 
-    // maybe some off by one errors, but otherwise the rotated images would not align 
-    // in the original positions. TODO: investigate & fix
+    // Note: the (-1) offsets are here (lines marked with // !) because it looks like
+    // the image shifts ~2 px to the left during the sync phase.
+    // So 2px that should be at the left edge turn out to be at the right edge.
+    // This causes some artifacts when the channels are rotated, since the offsets
+    // "bite into" the telemetry bands, that turn out on the left after rotation.
+    // This seems to fix it, but try to find if it's possible to do it during the 
+    // sync phase, and get rid of these here.
+    // Details here: https://github.com/martinber/noaa-apt/issues/26
 
     let mut channel_a = img.sub_image(
         x_offset, 0, PX_CHANNEL_IMAGE_DATA - 1, img.height() // !

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -3,7 +3,7 @@
 use image::{GenericImageView, GenericImage, GrayImage, ImageBuffer, Rgba};
 use log::info;
 
-use crate::decode::{PX_PER_CHANNEL, PX_PER_SYNC, PX_PER_SPACE_DATA, PX_PER_CHANNEL_IMAGE_DATA};
+use crate::decode::{PX_PER_CHANNEL, PX_SYNC_FRAME, PX_SPACE_DATA, PX_CHANNEL_IMAGE_DATA};
 use crate::err;
 use crate::geo;
 use crate::misc;
@@ -108,9 +108,9 @@ pub fn false_color(img: &mut ImageBuffer<Rgba<u8>, Vec<u8>>) {
     // hack to access IR channel at the same time
     let img_clone = img.clone(); 
 
-    const CHANNEL_IMAGE_START_OFFSET: u32 = PX_PER_SYNC + PX_PER_SPACE_DATA;
+    const CHANNEL_IMAGE_START_OFFSET: u32 = PX_SYNC_FRAME + PX_SPACE_DATA;
     const CHANNEL_IMAGE_END_OFFSET: u32 = CHANNEL_IMAGE_START_OFFSET + 
-        PX_PER_CHANNEL_IMAGE_DATA;
+        PX_CHANNEL_IMAGE_DATA;
 
     // colorize
     for x in 0..PX_PER_CHANNEL {

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -118,43 +118,43 @@ pub fn false_color(img: &mut ImageBuffer<Rgba<u8>, Vec<u8>>) {
             let val_pixel = img.get_pixel_mut(x, y);
             let irval_pixel = img_clone.get_pixel(x + PX_PER_CHANNEL, y);
 
-            let val = val_pixel[0];
-            let irval = irval_pixel[0];
+            let val = val_pixel[0] as f32;
+            let irval = irval_pixel[0] as f32;
 
-            let r;
-            let g;
-            let b;
+            let r: f32;
+            let g: f32;
+            let b: f32;
 
             if x < CHANNEL_IMAGE_START_OFFSET || x >= CHANNEL_IMAGE_END_OFFSET {
                 r = val;
                 g = val;
                 b = val;
-            } else if val < (13000 * 256 / 65536) as u8 {
+            } else if val < 13000. * 256. / 65536. {
                 // Water identification
-                r = (8.0 + val as f32 * 0.2) as u8;
-                g = (20.0 + val as f32 * 1.0) as u8;
-                b = (50.0 + val as f32 * 0.75) as u8;
+                r = 8.0 + val * 0.2;
+                g = 20.0 + val * 1.0;
+                b = 50.0 + val * 0.75;
             }
-            else if irval > (35000 * 256 / 65536) as u8 {
+            else if irval > 35000. * 256. / 65536. {
                 // Cloud/snow/ice identification
                 // IR channel helps distinguish clouds and water, particularly in arctic areas
-                r = (irval as f32 * 0.5 + val as f32) as u8; // Average the two for a little better cloud distinction
+                r = irval * 0.5 + val; // Average the two for a little better cloud distinction
                 g = r;
                 b = r;
             }            
-            else if val < (27000 * 256 / 65536) as u8 {
+            else if val < 27000. * 256. / 65536. {
                 // Vegetation identification
                 // green
-                r = (val as f32 * 0.8) as u8;
-                g = (val as f32 * 0.9) as u8;
-                b = (val as f32 * 0.6) as u8;
+                r = val * 0.8;
+                g = val * 0.9;
+                b = val * 0.6;
             }
-            else if val <= (35000 * 256 / 65536) as u8 {
+            else if val <= 35000. * 256. / 65536. {
                 // Desert/dirt identification
                 // brown
-                r = (val as f32 * 1.0) as u8;
-                g = (val as f32 * 0.9) as u8;
-                b = (val as f32 * 0.7) as u8;
+                r = val * 1.0;
+                g = val * 0.9;
+                b = val * 0.7;
             }
             else {
                 // Everything else, but this was probably captured by the IR channel above
@@ -164,8 +164,7 @@ pub fn false_color(img: &mut ImageBuffer<Rgba<u8>, Vec<u8>>) {
                 b = val;
             }
             
-            *val_pixel = image::Rgba([r, g, b, 255]);
-            // *irval_pixel = image::Rgba([r, g, b, 255]);
+            *val_pixel = image::Rgba([r as u8, g as u8, b as u8, 255]);
         }
     }
 }

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -138,7 +138,7 @@ pub fn false_color(img: &mut ImageBuffer<Rgba<u8>, Vec<u8>>) {
             else if irval > 35000. * 256. / 65536. {
                 // Cloud/snow/ice identification
                 // IR channel helps distinguish clouds and water, particularly in arctic areas
-                r = irval * 0.5 + val; // Average the two for a little better cloud distinction
+                r = (irval + val) * 0.5; // Average the two for a little better cloud distinction
                 g = r;
                 b = r;
             }            

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -103,9 +103,10 @@ pub fn histogram_equalization(img: &GrayImage) -> err::Result<GrayImage> {
 /// Needs a way to allow tweaking hardcoded values for water, land, ice
 /// and water detection, from the UI or command line.
 pub fn false_color(img: &mut ImageBuffer<Rgba<u8>, Vec<u8>>) {
+    info!("Colorize image (false color)");
+    
     // hack to access IR channel at the same time
-    // find a way to process each channel separately
-    let mut img_clone = img.clone(); 
+    let img_clone = img.clone(); 
 
     const CHANNEL_IMAGE_START_OFFSET: u32 = PX_PER_SYNC + PX_PER_SPACE_DATA;
     const CHANNEL_IMAGE_END_OFFSET: u32 = CHANNEL_IMAGE_START_OFFSET + 
@@ -115,7 +116,7 @@ pub fn false_color(img: &mut ImageBuffer<Rgba<u8>, Vec<u8>>) {
     for x in 0..PX_PER_CHANNEL {
         for y in 0..img.height() {
             let val_pixel = img.get_pixel_mut(x, y);
-            let irval_pixel = img_clone.get_pixel_mut(x + PX_PER_CHANNEL, y);
+            let irval_pixel = img_clone.get_pixel(x + PX_PER_CHANNEL, y);
 
             let val = val_pixel[0];
             let irval = irval_pixel[0];
@@ -164,7 +165,7 @@ pub fn false_color(img: &mut ImageBuffer<Rgba<u8>, Vec<u8>>) {
             }
             
             *val_pixel = image::Rgba([r, g, b, 255]);
-            *irval_pixel = image::Rgba([r, g, b, 255]);
+            // *irval_pixel = image::Rgba([r, g, b, 255]);
         }
     }
 }

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -101,7 +101,7 @@ pub fn histogram_equalization(img: &GrayImage) -> err::Result<GrayImage> {
 /// Attempts to produce a colored image from grayscale channel and IR data.
 /// Works best when contrast is set to "telemetry".
 /// Needs a way to allow tweaking hardcoded values for water, land, ice
-/// and water detection, from the UI or command line.
+/// and dirt detection, from the UI or command line.
 pub fn false_color(img: &mut ImageBuffer<Rgba<u8>, Vec<u8>>) {
     info!("Colorize image (false color)");
     

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -156,8 +156,8 @@ pub fn false_color(img: &mut ImageBuffer<Rgba<u8>, Vec<u8>>) {
                 g = (val as f32 * 0.9) as u8;
                 b = (val as f32 * 0.7) as u8;
             }
-            // Everything else, but this was probably captured by the IR channel above
             else {
+                // Everything else, but this was probably captured by the IR channel above
                 // Clouds, snow, and really dry desert
                 r = val;
                 g = val;


### PR DESCRIPTION
Adds an attempt to colorize the image using data from both channels. Based on the algorithm by [enigmastrat](https://github.com/enigmastrat/apt137/blob/feature/false_color/channel.c#L57).

I've had some good results for images where contrast adjustment was based on telemetry:

<img width="870" alt="europe-false-color" src="https://user-images.githubusercontent.com/1472875/90427931-e8fb7d00-e0cb-11ea-9e73-f258ca7ce86d.png">

For other input files (such as `argentina.wav`), it messes things up (maybe the wav file was normalized beforehand?):

![argentina-telemetry](https://user-images.githubusercontent.com/1472875/90390197-97370080-e093-11ea-8ac7-110d7bbf2610.png)

It kinda works when using histogram equalization:

![argentina_histogram](https://user-images.githubusercontent.com/1472875/90390229-ab7afd80-e093-11ea-8771-c07a4f9d29be.png)


For the future, maybe it's a good idea to show some sliders for the ice / grass / water / dirt threshold values on the UI and let the user tweak the image if it looks wrong.

There are some things I'm not really happy about (cloning the image to get a reference to IR channel while holding a mutable reference to the image for the visible channel).  Maybe you have some suggestions as well.