### PR TITLE
Allow app to work offline if map overlay option is not enabled

### DIFF
--- a/src/noaa_apt.rs
+++ b/src/noaa_apt.rs
@@ -187,13 +187,13 @@ pub fn process(
     // --------------------
 
     if let Some(orbit_settings) = orbit.clone() {
-        let tle = match orbit_settings.custom_tle {
-            Some(t) => t,
-            None => misc::get_current_tle()?,
-        };
-
         if let Some(map_settings) = orbit_settings.draw_map {
             context.status(0.5, "Drawing map".to_string());
+
+            let tle = match orbit_settings.custom_tle {
+                Some(t) => t,
+                None => misc::get_current_tle()?,
+            };
 
             map::draw_map(
                 &mut img,


### PR DESCRIPTION
Small tweak to allow the application to work offline if Map Overlay option is not used.

Otherwise it will fail if running offline, while fetching TLE data, even if not needed:

```
INFO  [noaa_apt::misc] Found outdated cached TLE. Date: 2021-03-14 17:53:12 UTC
                          Downloading and caching new TLE
ERROR [noaa_apt::gui::work] error sending request for url (https://www.celestrak.com/NORAD/elements/weather.txt): error trying to connect: dns error: failed to lookup address information: nodename nor servname provided, or not known
2
```

This is quite useful when an internet connection is not available.