### PR TITLE
Fixed OSX installation guide for nixos to nixpkgs

### DIFF
--- a/docs/download.md
+++ b/docs/download.md
@@ -108,9 +108,11 @@ After downloading and installing, visit [the Usage page](./usage.html).
 
     ```
     sh <(curl -L https://nixos.org/nix/install)
-    nix-env -iA nixos.noaa-apt
+    nix-env -iA nixpkgs.noaa-apt
     noaa-apt
     ```
+
+    If there is an error make sure your nix channels are up to date with `nix-channel --update`
 
 - [Otherwise compile it yourself following these instructions](./development.html#compilation).
 


### PR DESCRIPTION
Corrected error in OSX installation guide, `nix-env -iA nixos.noaa-apt` is incorrect as nixos is for a nix os system, for OSX nixpkgs is used instead. 
So `nix-env -iA nixpkgs.noaa-apt` is used for OSX.
(My system is an M2Air, Darwin 24.3 kernel with Sequia 15.3, for reference)

Also I got strange errors after installing nix fresh, so updating channels resolved that. This however might be limited to me, but its useful to know.